### PR TITLE
BUG: Fix failing tests due to missing method

### DIFF
--- a/OpenSoundControl/OpenSoundControl.py
+++ b/OpenSoundControl/OpenSoundControl.py
@@ -64,12 +64,12 @@ class OpenSoundControlWidget(ScriptedLoadableModuleWidget):
     self.buttonStopServer = qt.QPushButton("Stop server")
     self.buttonStopServer.toolTip = "Stop PureData server"
     self.buttonStopServer.connect('clicked()', self.stopServer)
-    
+
     hbox = qt.QHBoxLayout()
     hbox.addWidget(self.buttonStartServer)
     hbox.addWidget(self.buttonStopServer)
     pureDataFormLayout.addRow(hbox)
-    
+
 
     # Connection
 
@@ -257,10 +257,23 @@ class OpenSoundControlLogic(ScriptedLoadableModuleLogic):
 
     if not self.pureDataProcess:
       return
-      
+
     logging.info("Stopping PureData server")
     subprocess.Popen.terminate(self.pureDataProcess)
     self.pureDataProcess = None
+
+  def hasImageData(self,volumeNode):
+    """This is an example logic method that
+    returns true if the passed in volume
+    node has valid image data
+    """
+    if not volumeNode:
+      logging.debug('hasImageData failed: no volume node')
+      return False
+    if volumeNode.GetImageData() is None:
+      logging.debug('hasImageData failed: no image data in volume node')
+      return False
+    return True
 #
 # OpenSoundControlTest
 #

--- a/SoundNav/SoundNav.py
+++ b/SoundNav/SoundNav.py
@@ -308,10 +308,10 @@ class SoundNavLogic(ScriptedLoadableModuleLogic):
         instrumentNode,
         parameterNode.GetNodeReference("InstrumentReference"+str(instrumentIndex)),
         instrumentToReferenceMatrix)
-      
+
       instrumentToReference = vtk.vtkTransform()
       instrumentToReference.SetMatrix(instrumentToReferenceMatrix)
-      
+
       translation = instrumentToReference.GetPosition()
       orientation = instrumentToReference.GetOrientation()
       orientationWXYZ = instrumentToReference.GetOrientationWXYZ()
@@ -328,6 +328,20 @@ class SoundNavLogic(ScriptedLoadableModuleLogic):
 
       signedDistance = instrumentNode.GetClosestDistanceToModelFromToolTip()
       self.oscLogic.oscSendMessage(address+"Distance", signedDistance)
+
+  def hasImageData(self,volumeNode):
+    """This is an example logic method that
+    returns true if the passed in volume
+    node has valid image data
+    """
+    if not volumeNode:
+      logging.debug('hasImageData failed: no volume node')
+      return False
+    if volumeNode.GetImageData() is None:
+      logging.debug('hasImageData failed: no image data in volume node')
+      return False
+    return True
+
 
 class SoundNavTest(ScriptedLoadableModuleTest):
   """


### PR DESCRIPTION
This fixes [failing test 1](http://slicer.cdash.org/testDetails.php?test=9643425&build=1607727) and [failing test 2](http://slicer.cdash.org/testDetails.php?test=9643427&build=1607727) for Slicer 4.10.

I simply added the previously removed method which does a simple check to see if a volume node has image data.